### PR TITLE
Prepare v0.2.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.85"
 exclude = [".github/"]
 readme = "README.md"
 name = "linux-keyutils-keyring-store"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [[example]]

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::fmt::Formatter;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -10,11 +9,22 @@ use keyring_core::{Entry, Result};
 use super::Cred;
 
 /// The builder for keyutils credentials
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Store {
     pub id: String,
     pub delimiters: [String; 3],
     pub service_no_divider: bool,
+}
+
+impl std::fmt::Debug for Store {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Store")
+            .field("vendor", &self.vendor())
+            .field("id", &self.id())
+            .field("delimiters", &self.delimiters)
+            .field("service_no_divider", &self.service_no_divider)
+            .finish()
+    }
 }
 
 impl Store {
@@ -131,7 +141,7 @@ impl CredentialStoreApi for Store {
     }
 
     /// See the keychain-core API docs.
-    fn debug_fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn debug_fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Debug::fmt(self, f)
     }
 }


### PR DESCRIPTION
This is a cosmetic release that adds the vendor info to the store debug info. There are no functional changes.